### PR TITLE
Updates to tab completion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ depcomp
 etc/singularity.conf
 etc/Makefile
 etc/Makefile.in
+etc/bash_completion.d/singularity
 install-sh
 libexec/Makefile
 libexec/Makefile.in

--- a/etc/bash_completion.d/singularity.in
+++ b/etc/bash_completion.d/singularity.in
@@ -89,7 +89,7 @@ _singularity() {
                 # By default, bash considers ':' as a word separator.  We must thus strip the prefix docker: from our responses.
                 repo_name=$(echo ${cur} | sed -e 's|docker://\([-a-zA-Z0-9._]*\):.*|\1|')
                 response_var=$(echo ${cur} | sed -e 's|docker://[-a-zA-Z0-9._]*:||')
-                all_tags=$(PYTHONPATH="${exec_prefix}/libexec/singularity/python" python -c 'for i in __import__("docker.api").api.get_tags(namespace="library", repo_name=__import__("sys").argv[1]): print "%s" % i,' ${repo_name} 2>/dev/null)
+                all_tags=$(PYTHONPATH="${exec_prefix}/libexec/singularity/python" python -c 'for i in __import__("docker.shell").shell.get_tags_shell(image=__import__("sys").argv[1]): print("%s" % i),' ${repo_name} 2>/dev/null)
                 COMPREPLY=( $(compgen -W "${all_tags}" -- ${response_var}) )
             else
                 COMPREPLY=( $(compgen -W "docker" -S "://" -- ${cur}) )

--- a/libexec/python/cli.py
+++ b/libexec/python/cli.py
@@ -39,6 +39,8 @@ from docker.api import (
     get_manifest 
 )
 
+from docker.shell import parse_image_uri
+
 from utils import (
     basic_auth_header,
     change_permissions, 
@@ -196,29 +198,10 @@ def run(args):
         # Input Parsing ----------------------------
         # Parse image name, repo name, and namespace
 
-        # First split the docker image name by /
-        image = image.split('/')
-
-        # If there are two parts, we have namespace with repo (and maybe tab)
-        if len(image) == 2:
-            namespace = image[0]
-            image = image[1]
-
-        # Otherwise, we must be using library namespace
-        else:
-            namespace = "library"
-            image = image[0]
-
-        # Now split the docker image name by :
-        image = image.split(':')
-        if len(image) == 2:
-            repo_name = image[0]
-            repo_tag = image[1]
-
-        # Otherwise, assume latest of an image
-        else:
-            repo_name = image[0]
-            repo_tag = "latest"
+        image = parse_image_uri(image=image)
+        namespace = image['namespace']
+        repo_name = image['repo_name']
+        repo_tag = image['repo_tag']
 
         # Tell the user the namespace, repo name and tag
         logger.info("Docker image path: %s/%s:%s", namespace,repo_name,repo_tag)

--- a/libexec/python/docker/Makefile.am
+++ b/libexec/python/docker/Makefile.am
@@ -1,6 +1,6 @@
 scriptlibexecdir = $(libexecdir)/singularity/python/docker
 
-dist_scriptlibexec_DATA = api.py __init__.py converter.py
+dist_scriptlibexec_DATA = api.py __init__.py converter.py shell.py
 
 MAINTAINERCLEANFILES = Makefile.in
 

--- a/libexec/python/docker/shell.py
+++ b/libexec/python/docker/shell.py
@@ -39,10 +39,11 @@ def parse_image_uri(image):
     '''
 
     # First split the docker image name by /
+    image = image.replace('docker://','')
     image = image.split('/')
 
     # If there are two parts, we have namespace with repo (and maybe tab)
-    if len(image) == 2:
+    if len(image) >= 2:
         namespace = image[0]
         image = image[1]
 
@@ -74,12 +75,11 @@ def parse_image_uri(image):
 
 def get_tags_shell(image):
     '''get_tags_shell is a wrapper to run docker.api.get_tags with additional parsing
-    of the input string
+    of the input string. It is assumed that a tag is not provided.
     :image: the image name to be parsed by parse_image_uri
     '''
     parsed = parse_image_uri(image)
     repo_name = parsed['repo_name']
-    repo_tag = parsed['repo_tag']
     namespace = parsed['namespace']
 
     return get_tags(namespace=namespace,

--- a/libexec/python/docker/shell.py
+++ b/libexec/python/docker/shell.py
@@ -1,0 +1,86 @@
+'''
+
+shell.py: Docker shell parsing functions for Singularity in Python
+
+Copyright (c) 2016, Vanessa Sochat. All rights reserved. 
+
+"Singularity" Copyright (c) 2016, The Regents of the University of California,
+through Lawrence Berkeley National Laboratory (subject to receipt of any
+required approvals from the U.S. Dept. of Energy).  All rights reserved.
+ 
+This software is licensed under a customized 3-clause BSD license.  Please
+consult LICENSE file distributed with the sources of this project regarding
+your rights to use or distribute this software.
+ 
+NOTICE.  This Software was developed under funding from the U.S. Department of
+Energy and the U.S. Government consequently retains certain rights. As such,
+the U.S. Government has been granted for itself and others acting on its
+behalf a paid-up, nonexclusive, irrevocable, worldwide license in the Software
+to reproduce, distribute copies to the public, prepare derivative works, and
+perform publicly and display publicly, and to permit other to do so. 
+
+'''
+
+import sys
+sys.path.append('..') # parent directory
+
+from logman import logger
+from docker.api import get_tags
+import json
+import re
+import os
+
+
+def parse_image_uri(image):
+    '''parse_image_uri will return a json structure with a repo name, tag, and
+    namespace.
+    :param image: the string provided on command line for the image name, eg: ubuntu:latest
+    :returns parsed: a json structure with repo_name, repo_tag, and namespace
+    '''
+
+    # First split the docker image name by /
+    image = image.split('/')
+
+    # If there are two parts, we have namespace with repo (and maybe tab)
+    if len(image) == 2:
+        namespace = image[0]
+        image = image[1]
+
+    # Otherwise, we must be using library namespace
+    else:
+        namespace = "library"
+        image = image[0]
+
+    # Now split the docker image name by :
+    image = image.split(':')
+    if len(image) == 2:
+        repo_name = image[0]
+        repo_tag = image[1]
+
+    # Otherwise, assume latest of an image
+    else:
+        repo_name = image[0]
+        repo_tag = "latest"
+
+    logger.info("Repo Name: %s", repo_name)
+    logger.info("Repo Tag: %s", repo_tag)
+    logger.info("Namespace: %s", namespace)
+
+    parsed = {'repo_name':repo_name,
+              'repo_tag':repo_tag,
+              'namespace':namespace }
+    return parsed
+
+
+def get_tags_shell(image):
+    '''get_tags_shell is a wrapper to run docker.api.get_tags with additional parsing
+    of the input string
+    :image: the image name to be parsed by parse_image_uri
+    '''
+    parsed = parse_image_uri(image)
+    repo_name = parsed['repo_name']
+    repo_tag = parsed['repo_tag']
+    namespace = parsed['namespace']
+
+    return get_tags(namespace=namespace,
+                    repo_name=repo_name)


### PR DESCRIPTION
Hey @bbockelm ! I wasn't sure if you saw this, with my note in your original PR. I will repost here! I did some additions to keep this moving, and need your help for some of the bash part (see second paragraph).

This is a start that will get us closer to having tab completion for docker library (standard namespace) and custom registries! What I did is add a new python module called shell.py under the docker folder that can take in the entire clump of stuff before the ":", and then parse from that the namespace, and repo_name.

It still works for standard images (like centos) and running the functions alone, the python calls should technically work for tensorflow/tensorflow:, but I think it's hiccuping on something with the bash sniffing part, because the output never gets printed (I think it might be the second / gets read in again, or something like that). If you have some time over break, could you take a look? Once we figure out this last thing, I think the bash completion should work for all different kinds of registries!